### PR TITLE
Add __main__.py to allow "python -m openconnect_pulse_gui"

### DIFF
--- a/openconnect_pulse_gui/__main__.py
+++ b/openconnect_pulse_gui/__main__.py
@@ -1,0 +1,3 @@
+from .openconnect_pulse_gui import main
+
+main()


### PR DESCRIPTION
```
*  Add __main__.py to allow "python -m openconnect_pulse_gui"
   
   Such invocation is convenient if it's unknown where the package is
   installed and whether openconnect_pulse_gui is in PATH. It also allows
   specifying the Python interpreter.
```