### PR TITLE
Unhide options for persistent cookies

### DIFF
--- a/openconnect_pulse_gui/openconnect_pulse_gui.py
+++ b/openconnect_pulse_gui/openconnect_pulse_gui.py
@@ -227,13 +227,13 @@ def parse_args(args=None):
         "-p",
         "--persist-cookies",
         action="store_true",
-        help=argparse.SUPPRESS,  # "Save non-session cookies to disk",
+        help="Save non-session cookies to a file",
     )
     p.add_argument(
         "-c",
         "--cookie-file",
         default="~/.config/pulse-gui-cookies",
-        help=argparse.SUPPRESS,  # "Store cookies in this file (instead of default %(default)s)",
+        help="File to store non-session cookies (default: %(default)s)",
     )
     args = p.parse_args(args=None)
 


### PR DESCRIPTION
```
*  Unhide options for persistent cookies
   
   Storage in subdirectories of the user's home directory is not generally
   considered insecure. For instance, ~/.ssh contains ssh private keys that
   can be used to access other systems.
```