### PR TITLE
Set program name to the package name when run through __main__.py

### DIFF
--- a/openconnect_pulse_gui/__main__.py
+++ b/openconnect_pulse_gui/__main__.py
@@ -1,3 +1,3 @@
 from .openconnect_pulse_gui import main
 
-main()
+main(prog=__package__)

--- a/openconnect_pulse_gui/openconnect_pulse_gui.py
+++ b/openconnect_pulse_gui/openconnect_pulse_gui.py
@@ -188,8 +188,8 @@ class PulseLoginView:
                     self._window.destroy()
 
 
-def parse_args(args=None):
-    p = argparse.ArgumentParser()
+def parse_args(args=None, prog=None):
+    p = argparse.ArgumentParser(prog=prog)
     p.add_argument("server", help="Pulse Secure Connect URL")
     p.add_argument(
         "--insecure", action="store_true", help="Ignore invalid server certificate",
@@ -291,8 +291,8 @@ def saml_thread(jobQ, returnQ, closeEvent):
             returnQ.put({"auth_cookie": slv.auth_cookie})
 
 
-def main():
-    p, args = parse_args()
+def main(prog=None):
+    p, args = parse_args(prog=prog)
 
     log_levels = [logging.WARNING, logging.INFO, logging.DEBUG]
     if args.verbose > 2:


### PR DESCRIPTION
Otherwise the program name is showing as `__main__.py`:

```
$ python -m openconnect_pulse_gui
usage: __main__.py [-h] [--insecure] [-v | -q] server
__main__.py: error: the following arguments are required: server
```

Corrected behavior:

```
$ python -m openconnect_pulse_gui
usage: openconnect_pulse_gui [-h] [--insecure] [-v | -q] server
openconnect_pulse_gui: error: the following arguments are required: server
```

In other cases, keep using the default name `os.path.basename(sys.argv[0])`

```
$ ~/.local/bin/openconnect-pulse-gui
usage: openconnect-pulse-gui [-h] [--insecure] [-v | -q] server
openconnect-pulse-gui: error: the following arguments are required: server
```

```
$ ./openconnect_pulse_gui.py
usage: openconnect_pulse_gui.py [-h] [--insecure] [-v | -q] server
openconnect_pulse_gui.py: error: the following arguments are required: server
```