### PR TITLE
Call show_all() at the end of PulseLoginView constructor

### DIFF
--- a/openconnect_pulse_gui/openconnect_pulse_gui.py
+++ b/openconnect_pulse_gui/openconnect_pulse_gui.py
@@ -69,7 +69,6 @@ class PulseLoginView:
 
         self._window.resize(500, 500)
         self._window.add(self._webview)
-        self._window.show_all()
         self._window.set_title("Pulse Connect Login")
         self._window.connect("delete-event", self._user_close)
         self._window.connect("destroy", self._close)
@@ -82,6 +81,8 @@ class PulseLoginView:
             self._webview.load_html(html, uri)
         else:
             self._webview.load_uri(uri)
+
+        self._window.show_all()
 
     def _user_close(self, *args, **kwargs):
         self.user_closed = True


### PR DESCRIPTION
Most WebKit2 tutorials put show_all() to the end of the window
construction, immediately before Gtk.main(). That can save rendering
time, as the window doesn't need to be redrawn while its contents and
properties are being defined.