### PR TITLE
Suppress warnings with -q/--quiet

### DIFF
--- a/openconnect_pulse_gui/openconnect_pulse_gui.py
+++ b/openconnect_pulse_gui/openconnect_pulse_gui.py
@@ -33,7 +33,7 @@ class PulseLoginView:
         self,
         uri,
         html=None,
-        verbose=False,
+        verbose=0,
         cookies=None,
         verify=True,
         session_cookie_name="DSID",
@@ -209,9 +209,7 @@ def parse_args(args=None, prog=None):
     x.add_argument(
         "-q",
         "--quiet",
-        dest="verbose",
-        action="store_const",
-        const=0,
+        action="store_true",
         help="Reduce verbosity to a minimum",
     )
 
@@ -294,7 +292,9 @@ def main(prog=None):
     p, args = parse_args(prog=prog)
 
     log_levels = [logging.WARNING, logging.INFO, logging.DEBUG]
-    if args.verbose > 2:
+    if args.quiet:
+        log_level = logging.ERROR
+    elif args.verbose >= len(log_levels):
         log_level = log_levels[-1]
     else:
         log_level = log_levels[args.verbose]


### PR DESCRIPTION
```
*  Suppress warnings with -q/--quiet
   
   The -q/--quiet option had no effect. Make it suppress warnings, only log
   errors.
   
   Change the verbose default in PulseLoginView constructor from False to 0.
   The default is never used, but verbose is supposed to be an integer, not
   a boolean value.
```